### PR TITLE
Python3

### DIFF
--- a/geocoder/__init__.py
+++ b/geocoder/__init__.py
@@ -40,4 +40,4 @@ from .api import maxmind, freegeoip, ottawa
 from .api import timezone, elevation, ip, canadapost, reverse
 
 # CLI
-from cli import cli
+from .cli import cli

--- a/geocoder/arcgis.py
+++ b/geocoder/arcgis.py
@@ -2,7 +2,7 @@
 # coding: utf8
 
 import re
-from base import Base
+from .base import Base
 
 
 class Arcgis(Base):

--- a/geocoder/base.py
+++ b/geocoder/base.py
@@ -5,7 +5,7 @@ import requests
 import sys
 import json
 from collections import defaultdict
-from haversine import haversine
+from .haversine import haversine
 
 
 class Base(object):
@@ -106,39 +106,39 @@ class Base(object):
         self.json['ok'] = self.ok
 
     def debug(self):
-        print(json.dumps(self.parse, indent=4))
-        print(json.dumps(self.json, indent=4))
-        print ''
-        print 'OSM Quality'
-        print '---------------'
+        print((json.dumps(self.parse, indent=4)))
+        print((json.dumps(self.json, indent=4)))
+        print('')
+        print('OSM Quality')
+        print('---------------')
         count = 0
         for key in self.osm:
             if 'addr:' in key:
                 if self.json.get(key.replace('addr:','')):
-                    print '[x]', key
+                    print('[x]', key)
                     count += 1
                 else:
-                    print '[ ]', key
-        print '({0}/{1})'.format(count, len(self.osm) - 2)
-        print ''
-        print 'Attributes'
-        print '--------------'
+                    print('[ ]', key)
+        print('({0}/{1})'.format(count, len(self.osm) - 2))
+        print('')
+        print('Attributes')
+        print('--------------')
         count = 0
         for attribute in self.attributes:
             if self.json.get(attribute):
-                print '[x]', attribute
+                print('[x]', attribute)
                 count += 1
             else:
-                print '[ ]',attribute
-        print '({0}/{1})'.format(count, len(self.attributes))
-        print ''
-        print 'URL'
-        print '---'
-        print self.url
-        print ''
-        print 'Repr'
-        print '----'
-        print self
+                print('[ ]',attribute)
+        print('({0}/{1})'.format(count, len(self.attributes)))
+        print('')
+        print('URL')
+        print('---')
+        print(self.url)
+        print('')
+        print('Repr')
+        print('----')
+        print(self)
 
     def _exceptions(self):
         pass
@@ -148,16 +148,13 @@ class Base(object):
     def _build_tree(self, content, last=''):
         if content:
             if isinstance(content, dict):
-                for key, value in content.items():
+                for key, value in list(content.items()):
                     # Rebuild the tree if value is a dictionary
                     if isinstance(value, dict):
                         self._build_tree(value, last=key)
                     else:
-                        # Convert all endpoint strings as UTF-8 encoding
-                        if isinstance(value, (str, unicode)):
-                            value = value.encode('utf-8')
                         if key == 'town':
-                            print value
+                            print(value)
 
                             exit()
                         if last:

--- a/geocoder/base.py
+++ b/geocoder/base.py
@@ -115,10 +115,10 @@ class Base(object):
         for key in self.osm:
             if 'addr:' in key:
                 if self.json.get(key.replace('addr:','')):
-                    print('[x]', key)
+                    print('[x] {0}'.format(key))
                     count += 1
                 else:
-                    print('[ ]', key)
+                    print('[ ] {0}'.format(key))
         print('({0}/{1})'.format(count, len(self.osm) - 2))
         print('')
         print('Attributes')
@@ -126,10 +126,10 @@ class Base(object):
         count = 0
         for attribute in self.attributes:
             if self.json.get(attribute):
-                print('[x]', attribute)
+                print('[x] {0}'.format(attribute))
                 count += 1
             else:
-                print('[ ]',attribute)
+                print('[ ] {0}'.format(attribute))
         print('({0}/{1})'.format(count, len(self.attributes)))
         print('')
         print('URL')

--- a/geocoder/base.py
+++ b/geocoder/base.py
@@ -106,8 +106,8 @@ class Base(object):
         self.json['ok'] = self.ok
 
     def debug(self):
-        print((json.dumps(self.parse, indent=4)))
-        print((json.dumps(self.json, indent=4)))
+        print(json.dumps(self.parse, indent=4))
+        print(json.dumps(self.json, indent=4))
         print('')
         print('OSM Quality')
         print('---------------')

--- a/geocoder/base.py
+++ b/geocoder/base.py
@@ -148,7 +148,7 @@ class Base(object):
     def _build_tree(self, content, last=''):
         if content:
             if isinstance(content, dict):
-                for key, value in list(content.items()):
+                for key, value in content.items():
                     # Rebuild the tree if value is a dictionary
                     if isinstance(value, dict):
                         self._build_tree(value, last=key)

--- a/geocoder/bing.py
+++ b/geocoder/bing.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from keys import bing_key
+from .base import Base
+from .keys import bing_key
 import json
 import re
 

--- a/geocoder/bing_reverse.py
+++ b/geocoder/bing_reverse.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from bing import Bing
-from keys import bing_key
-from location import Location
+from .base import Base
+from .bing import Bing
+from .keys import bing_key
+from .location import Location
 
 
 class BingReverse(Bing, Base):

--- a/geocoder/canadapost.py
+++ b/geocoder/canadapost.py
@@ -3,9 +3,9 @@
 
 import re
 import requests
-from base import Base
-from keys import canadapost_key
-from location import Location
+from .base import Base
+from .keys import canadapost_key
+from .location import Location
 
 
 class Canadapost(Base):

--- a/geocoder/cli.py
+++ b/geocoder/cli.py
@@ -3,7 +3,7 @@ import fileinput
 import itertools
 import json
 import sys
-from api import get
+from .api import get
 
 def peek(iterable):
     iterator = iter(iterable)
@@ -25,7 +25,7 @@ def cli():
 
     try:
         sys.argv = [sys.argv[1]] + args.input
-	input = fileinput.input()
+        input = fileinput.input()
         _, input = peek(input)
     except IOError:
         input = args.input

--- a/geocoder/elevation.py
+++ b/geocoder/elevation.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from location import Location
+from .base import Base
+from .location import Location
 
 
 class Elevation(Base):

--- a/geocoder/freegeoip.py
+++ b/geocoder/freegeoip.py
@@ -3,7 +3,7 @@
 
 import requests
 import ratelim
-from base import Base
+from .base import Base
 
 
 class FreeGeoIP(Base):

--- a/geocoder/geolytica.py
+++ b/geocoder/geolytica.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
+from .base import Base
 
 class Geolytica(Base):
     """

--- a/geocoder/geonames.py
+++ b/geocoder/geonames.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from keys import geonames_username
+from .base import Base
+from .keys import geonames_username
 
 
 class Geonames(Base):

--- a/geocoder/google.py
+++ b/geocoder/google.py
@@ -197,4 +197,4 @@ if __name__ == '__main__':
     #import json
     #print json.dumps(g.osm, indent=4)
     #g.debug()
-    print g.wkt
+    print(g.wkt)

--- a/geocoder/google.py
+++ b/geocoder/google.py
@@ -3,7 +3,7 @@
 
 import ratelim
 import requests
-from base import Base
+from .base import Base
 
 
 class Google(Base):
@@ -88,8 +88,8 @@ class Google(Base):
             # Parse address components with short & long names
             for item in self.parse['address_components']:
                 for category in item['types']:
-                    self.parse[category]['long_name'] = item['long_name'].encode('utf-8')
-                    self.parse[category]['short_name'] = item['short_name'].encode('utf-8')
+                    self.parse[category]['long_name'] = item['long_name']
+                    self.parse[category]['short_name'] = item['short_name']
 
     @property
     def lat(self):

--- a/geocoder/google_reverse.py
+++ b/geocoder/google_reverse.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from google import Google
-from location import Location
+from .base import Base
+from .google import Google
+from .location import Location
 
 
 class GoogleReverse(Google, Base):

--- a/geocoder/location.py
+++ b/geocoder/location.py
@@ -101,9 +101,9 @@ class Location(object):
 if __name__ == '__main__':
 
     l = Location({'y':'45.123', 'x':0.0})
-    print l
-    print l.latlng
+    print(l)
+    print(l.latlng)
 
-    print l.ok
-    print l.lat
-    print l.lng
+    print(l.ok)
+    print(l.lat)
+    print(l.lng)

--- a/geocoder/mapquest.py
+++ b/geocoder/mapquest.py
@@ -3,8 +3,8 @@
 
 import re
 import requests
-from base import Base
-from keys import mapquest_key
+from .base import Base
+from .keys import mapquest_key
 
 
 class Mapquest(Base):

--- a/geocoder/mapquest_reverse.py
+++ b/geocoder/mapquest_reverse.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from keys import mapquest_key
-from mapquest import Mapquest
-from location import Location
+from .base import Base
+from .keys import mapquest_key
+from .mapquest import Mapquest
+from .location import Location
 
 
 class MapquestReverse(Mapquest, Base):

--- a/geocoder/maxmind.py
+++ b/geocoder/maxmind.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
+from .base import Base
 
 
 class Maxmind(Base):

--- a/geocoder/nokia.py
+++ b/geocoder/nokia.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from keys import app_id, app_code
+from .base import Base
+from .keys import app_id, app_code
 
 
 class Nokia(Base):

--- a/geocoder/opencage.py
+++ b/geocoder/opencage.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from keys import opencage_key
+from .base import Base
+from .keys import opencage_key
 
 
 class OpenCage(Base):

--- a/geocoder/opencage_reverse.py
+++ b/geocoder/opencage_reverse.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from keys import opencage_key
-from opencage import OpenCage
-from location import Location
+from .base import Base
+from .keys import opencage_key
+from .opencage import OpenCage
+from .location import Location
 
 
 class OpenCageReverse(OpenCage, Base):

--- a/geocoder/osm.py
+++ b/geocoder/osm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
+from .base import Base
 
 
 class Osm(Base):

--- a/geocoder/ottawa.py
+++ b/geocoder/ottawa.py
@@ -2,7 +2,7 @@
 # coding: utf8
 
 import re
-from base import Base
+from .base import Base
 
 
 class Ottawa(Base):

--- a/geocoder/timezone.py
+++ b/geocoder/timezone.py
@@ -2,8 +2,8 @@
 # coding: utf8
 
 import time
-from base import Base
-from location import Location
+from .base import Base
+from .location import Location
 
 
 class Timezone(Base):

--- a/geocoder/tomtom.py
+++ b/geocoder/tomtom.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
-from keys import tomtom_key
+from .base import Base
+from .keys import tomtom_key
 
 class Tomtom(Base):
     """

--- a/geocoder/yahoo.py
+++ b/geocoder/yahoo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf8
 
-from base import Base
+from .base import Base
 
 
 class Yahoo(Base):

--- a/test_geocoder.py
+++ b/test_geocoder.py
@@ -7,6 +7,7 @@ import unittest
 
 address = '453 Booth Street, Ottawa'
 location = 'Ottawa, Ontario'
+city = 'Ottawa'
 ip = '74.125.226.99'
 repeat = 3
 ottawa = (45.4215296, -75.6971930)
@@ -48,6 +49,7 @@ def test_maxmind():
 def test_google():
     g = geocoder.google(location)
     assert g.ok
+    assert g.city == city
 
 def test_google_reverse():
     g = geocoder.google(ottawa, method='reverse')
@@ -64,6 +66,7 @@ def test_google_elevation():
 def test_bing():
     g = geocoder.bing(location)
     assert g.ok
+    assert g.city == city
 
 def test_bing_reverse():
     g = geocoder.bing(ottawa, method='reverse')
@@ -72,6 +75,7 @@ def test_bing_reverse():
 def test_opencage():
     g = geocoder.opencage(location)
     assert g.ok
+    assert g.city == city
     
 def test_opencage_reverse():
     g = geocoder.opencage(ottawa, method='reverse')
@@ -80,6 +84,7 @@ def test_opencage_reverse():
 def test_yahoo():
     g = geocoder.yahoo(location)
     assert g.ok
+    assert g.city == city
 
 def test_arcgis():
     g = geocoder.arcgis(location)
@@ -96,20 +101,23 @@ def test_canadapost():
 def test_nokia():
     g = geocoder.nokia(location)
     assert g.ok
+    assert g.city == city
 
 def test_osm():
     g = geocoder.osm(location)
     assert g.ok
+    assert g.city == city
 
 def test_tomtom():
     g = geocoder.tomtom(location)
     assert g.ok
+    assert g.city == city
 
 def test_mapquest():
     g = geocoder.mapquest(location)
     assert g.ok
+    assert g.city == city
 
 def test_geonames():
     g = geocoder.geonames(location)
     assert g.ok
-    

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py34
+[testenv]
+deps=pytest
+commands=py.test {posargs}


### PR DESCRIPTION
1. Added `tox.ini` to test Python 2.7 and 3.4.
2. Run `2to3` tool on all codebase (mainly `print` and `import` fixes).
  Few fixes were adjusted by hand (`print` and `items()`)
3. Fixed mixed tabs/spaces indentation.
4. Removed `encode('utf-8')` in 3 lines.
  About this I'm not 100% sure, but old code produced `bytes` in Python 3 and was generally weird. It seems to work fine without it (I checked on Russian location names). 
  To ensure that in Python 3 API doesn't expose raw `bytes`, I added city check to tests.

NOTE: `ratelim` package doesn't have Python 3 support. Fixing it is easy, I'll send pull request there too.