### PR TITLE
Modified Here code to accept custom URL and Qualifed Address.

### DIFF
--- a/geocoder/here.py
+++ b/geocoder/here.py
@@ -20,9 +20,10 @@ class Here(Base):
     """
     provider = 'here'
     method = 'geocode'
+    qualified_address = ['city', 'district', 'postal', 'state', 'country']
 
     def __init__(self, location, **kwargs):
-        self.url = 'http://geocoder.api.here.com/6.2/geocode.json'
+        self.url = kwargs.get('url','http://geocoder.api.here.com/6.2/geocode.json')
         self.location = location
         self.params = {
             'searchtext': location,
@@ -31,6 +32,9 @@ class Here(Base):
             'gen': 8,
             'language': kwargs.get('language', 'en')
         }
+        for value in Here.qualified_address:
+            if kwargs.get(value) is not None:
+                self.params[value] = kwargs.get(value)
         self._initialize(**kwargs)
 
     def _exceptions(self):


### PR DESCRIPTION
CHANGE 1 : Currently HERE Geocoder code has HardCoded URL "http://geocoder.api.here.com/6.2/geocode.json". I made a change so that it can accept custom URL from User or use the default url if nothing is passed.

CHANGE 2 : Currently HERE Geocoder accept only complete Address which it pass as "searchtext" to HERE API for Geocoder. While HERE API can accept qualified address field for better result. Qualified Address Field mean city name passed to city parameter, state name is passed as state parameter and so forth.