### PR TITLE
fix geocoding for street crossings...

### DIFF
--- a/geocoder/geolytica.py
+++ b/geocoder/geolytica.py
@@ -44,23 +44,38 @@ class Geolytica(Base):
 
     @property
     def postal(self):
-        return self.parse.get('postal').strip()
+        try:
+            return self.parse.get('postal').strip()
+        except AttributeError:
+            pass
 
     @property
     def housenumber(self):
-        return self.parse['standard'].get('stnumber').strip()
+        try:
+            return self.parse['standard'].get('stnumber').strip()
+        except AttributeError:
+            pass
 
     @property
     def street(self):
-        return self.parse['standard'].get('staddress').strip()
+        try:
+            return self.parse['standard'].get('staddress').strip()
+        except AttributeError:
+            pass
 
     @property
     def city(self):
-        return self.parse['standard'].get('city').strip()
+        try:
+            return self.parse['standard'].get('city').strip()
+        except AttributeError:
+            pass
 
     @property
     def state(self):
-        return self.parse['standard'].get('prov').strip()
+        try:
+            return self.parse['standard'].get('prov').strip()
+        except AttributeError:
+            pass
 
     @property
     def address(self):


### PR DESCRIPTION
Hi Denis,

Today I hit the following "address" (it's a place in fact): 'Maple Street & West 3rd Avenue, Vancouver, BC'.
There is no unique house number, street, postal code etc., but still geocoder.ca (geolytica) is able to return coordinates:
http://geocoder.ca/?locate=Maple+Street+%26+West+3rd+Avenue%2C+Vancouver%2C+BC&geoit=GeoCode

Current version fails with following error:
```
Traceback (most recent call last):
  ...
  File ".../site-packages/geocoder/base.py", line 128, in _initialize
    self._json()
  File ".../site-packages/geocoder/base.py", line 134, in _json
    value = getattr(self, key)
  File ".../site-packages/geocoder/geolytica.py", line 65, in address
    if self.street_number:
  File ".../site-packages/geocoder/base.py", line 345, in street_number
    return self.housenumber
  File ".../site-packages/geocoder/geolytica.py", line 49, in housenumber
    return self.parse['standard'].get('stnumber').strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```
This pull request fixes the error and the geocoder lib can return the coordinates.