### PR TITLE
added test_google_for_work() in test_geocoder.py

### DIFF
--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -115,10 +115,14 @@ def test_baidu():
 
 
 def test_google():
-    g = geocoder.google(location)
+    g = geocoder.google(location, client = None)
     assert g.ok
     assert str(g.city) == city
 
+def test_google_for_work():
+    g = geocoder.google(location)
+    assert g.ok
+    assert str(g.city) == city
 
 def test_google_reverse():
     g = geocoder.google(ottawa, method='reverse')


### PR DESCRIPTION
test_google() now explicitly sets the `client` to None so that the value is not taken from local environment variables.