### PR TITLE
fix for when there is an accent in the *result*

### DIFF
--- a/geocoder/bing.py
+++ b/geocoder/bing.py
@@ -81,7 +81,7 @@ class Bing(Base):
         if self.street:
             expression = r'\d+'
             pattern = re.compile(expression)
-            match = pattern.search(str(self.street))
+            match = pattern.search(self.street,re.UNICODE)
             if match:
                 return match.group(0)
 


### PR DESCRIPTION
`geocoder.bing('1 rue bergere, paris',key=bing_key)`
used to trigger error
`UnicodeEncodeError: 'ascii' codec can't encode character...`