### PR TITLE
a couple Tamu updates

### DIFF
--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -118,19 +118,19 @@ class Tamu(Base):
 
     @property
     def street(self):
-        name = self.parse.get('Name')
-        suffix = self.parse.get('Suffix')
+        name = self.parse.get('Name','')
+        suffix = self.parse.get('Suffix','')
         return ' '.join([name, suffix]).strip()
 
     @property
     def address(self):
         return ' '.join([
-            self.parse.get('Number'),
-            self.parse.get('Name'),
-            self.parse.get('Suffix'),
-            self.parse.get('City'),
-            self.parse.get('State'),
-            self.parse.get('Zip')])
+            self.parse.get('Number',''),
+            self.parse.get('Name',''),
+            self.parse.get('Suffix',''),
+            self.parse.get('City',''),
+            self.parse.get('State',''),
+            self.parse.get('Zip','')])
 
     @property
     def city(self):

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -27,7 +27,7 @@ class Tamu(Base):
     provider = 'tamu'
     method = 'geocode'
 
-    def __init__(self, location, **kwargs):
+    def __init__(self, location, censusYears=('1990','2000','2010'), **kwargs):
         # city, state, zip
         city = kwargs.get('city', '')
         state = kwargs.get('state', '')
@@ -50,7 +50,7 @@ class Tamu(Base):
             'apikey': key,
             'format': 'json',
             'census': 'true',
-            'censusYear': '1990|2000|2010',
+            'censusYear': '|'.join(censusYears),
             'notStore': 'false',
             'verbose': 'true',
             'version': '4.01'

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -78,8 +78,8 @@ class Tamu(Base):
         # Build initial Tree with results
         if self.parse['OutputGeocodes']:
             self._build_tree(self.parse.get('OutputGeocodes')[0])
-            self._build_tree(self.parse.get('MatchedAddress'))
             self._build_tree(self.parse.get('OutputGeocode'))
+            self._build_tree(self.parse.get('ReferenceFeature'))
 
         if self.parse['CensusValues']:
             self._build_tree(self.parse.get('CensusValues')[0]['CensusValue1'])
@@ -123,7 +123,9 @@ class Tamu(Base):
 
     @property
     def address(self):
-        return self.parse['InputAddress'].get('StreetAddress')
+#        return self.parse['InputAddress'].get('StreetAddress')
+        return ' '.join([
+            self.housenumber, self.street, self.city, self.state, self.postal])
 
     @property
     def city(self):

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -181,7 +181,6 @@ if __name__ == '__main__':
         '595 Market Street',
         city="San Francisco",
         state="CA",
-        zipcode="94105",
-        key="demo")
+        zipcode="94105")
 
     g.debug()

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -77,10 +77,9 @@ class Tamu(Base):
     def _exceptions(self):
         # Build initial Tree with results
         if self.parse['OutputGeocodes']:
-            if self.parse.get('OutputGeocodes'):
-                self._build_tree(self.parse.get('OutputGeocodes')[0])
-                self._build_tree(self.parse.get('MatchedAddress'))
-                self._build_tree(self.parse.get('OutputGeocode'))
+            self._build_tree(self.parse.get('OutputGeocodes')[0])
+            self._build_tree(self.parse.get('MatchedAddress'))
+            self._build_tree(self.parse.get('OutputGeocode'))
 
         if self.parse['CensusValues']:
             self._build_tree(self.parse.get('CensusValues')[0]['CensusValue1'])

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -125,7 +125,12 @@ class Tamu(Base):
     @property
     def address(self):
         return ' '.join([
-            self.housenumber, self.street, self.city, self.state, self.postal])
+            self.parse.get('Number'),
+            self.parse.get('Name'),
+            self.parse.get('Suffix'),
+            self.parse.get('City'),
+            self.parse.get('State'),
+            self.parse.get('Zip')])
 
     @property
     def city(self):

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 from geocoder.base import Base
 from geocoder.keys import tamu_key
 
+
 class Tamu(Base):
     """
     TAMU Geocoding Services
@@ -27,7 +28,9 @@ class Tamu(Base):
     provider = 'tamu'
     method = 'geocode'
 
-    def __init__(self, location, censusYears=('1990','2000','2010'), **kwargs):
+    def __init__(
+            self, location, censusYears=('1990', '2000', '2010'), **kwargs):
+
         # city, state, zip
         city = kwargs.get('city', '')
         state = kwargs.get('state', '')
@@ -41,7 +44,8 @@ class Tamu(Base):
             raise ValueError("Provide key")
 
         self.location = location
-        self.url = 'https://geoservices.tamu.edu/Services/Geocode/WebService/GeocoderWebServiceHttpNonParsed_V04_01.aspx'
+        self.url = 'https://geoservices.tamu.edu/Services/Geocode/WebService/'\
+                   'GeocoderWebServiceHttpNonParsed_V04_01.aspx'
         self.params = {
             'streetAddress': location,
             'city': city,

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -119,19 +119,19 @@ class Tamu(Base):
 
     @property
     def street(self):
-        name = self.parse.get('Name','')
-        suffix = self.parse.get('Suffix','')
+        name = self.parse.get('Name', '')
+        suffix = self.parse.get('Suffix', '')
         return ' '.join([name, suffix]).strip()
 
     @property
     def address(self):
         return ' '.join([
-            self.parse.get('Number',''),
-            self.parse.get('Name',''),
-            self.parse.get('Suffix',''),
-            self.parse.get('City',''),
-            self.parse.get('State',''),
-            self.parse.get('Zip','')])
+            self.parse.get('Number', ''),
+            self.parse.get('Name', ''),
+            self.parse.get('Suffix', ''),
+            self.parse.get('City', ''),
+            self.parse.get('State', ''),
+            self.parse.get('Zip', '')])
 
     @property
     def city(self):

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -42,6 +42,7 @@ class Tamu(Base):
         key = kwargs.get('key', tamu_key)
         if not key:
             raise ValueError("Provide key")
+        self.key = key
 
         self.location = location
         self.url = 'https://geoservices.tamu.edu/Services/Geocode/WebService/'\

--- a/geocoder/tamu.py
+++ b/geocoder/tamu.py
@@ -116,14 +116,10 @@ class Tamu(Base):
     def street(self):
         name = self.parse.get('Name')
         suffix = self.parse.get('Suffix')
-        if suffix:
-            return ' '.join([name, suffix])
-        else:
-            return name
+        return ' '.join([name, suffix]).strip()
 
     @property
     def address(self):
-#        return self.parse['InputAddress'].get('StreetAddress')
         return ' '.join([
             self.housenumber, self.street, self.city, self.state, self.postal])
 

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -70,6 +70,7 @@ def test_freegeoip():
     assert g.ok
 """
 
+
 def test_mapbox():
     g = geocoder.mapbox(location)
     assert g.ok

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -245,6 +245,5 @@ def test_tamu():
         us_address,
         city=us_city,
         state=us_state,
-        zipcode=us_zipcode,
-        key='demo')
+        zipcode=us_zipcode)
     assert g.ok


### PR DESCRIPTION
Hi Denis, Thanks for cleaning this up after the merge!  Much better - I think you were right about the string vs boolean being the issue (and not parameter-order, as I had thought). 

I made a couple updates:

* removed explicit tamu key in __main__  and test module
* added ability to pass census years if desired, but defaults to (1999, 2000, 2010)
* used ReferenceFeature instead of MatchedAddress from Tamu's output for address items (MatchedAddress is actually the input data being passed back, not the corrected/parsed address as I originally thought...  ReferenceFeature is the corrected/parsed field, so if things like street suffix were omitted from the location input, they get appear and are corrected now in the output).

Cheers,
Michael