### PR TITLE
Prevent a memory leak

### DIFF
--- a/geocoder/base.py
+++ b/geocoder/base.py
@@ -136,6 +136,7 @@ class Base(object):
         ###
 
     def _json(self):
+        self.fieldnames = []
         for key in dir(self):
             if not key.startswith('_') and key not in self._exclude:
                 self.fieldnames.append(key)


### PR DESCRIPTION
Base.fieldnames was created as a class variable and wasn't being cleared every time a new instance was created, so every query, new fields were added in the Base._json(). So if you did something like:

g = geocoder.google(query1)
g = geocoder.google(query2)

g.debug() will show you fieldnames has duplicate keys.