### PR TITLE
Do not catch all exceptions and flag connection issues as "404"

### DIFF
--- a/geocoder/base.py
+++ b/geocoder/base.py
@@ -103,9 +103,6 @@ class Base(object):
         except requests.exceptions.SSLError:
             self.status_code = 495
             self.error = 'ERROR - SSLError'
-        except:
-            self.status_code = 404
-            self.error = 'ERROR - URL Connection'
 
         # Open JSON content from Request connection
         if self.status_code == 200:


### PR DESCRIPTION
We had some timeout issues against the Google reverse geocoding API.

The timeout value inside my Docker container is now defined as an environment variable - which are strings by definition. So it took me quite a while to find out, why I always received a `404` from the geocoder library, although there was a very specific exception thrown internally:

```TypeError: a float is required```

Also, there is currently no chance to find out about timeouts, if all connection errors are caught and flagged as `404`.

Best
Fabian