### PR TITLE
Added option to modify server url for custom mapzen server

### DIFF
--- a/geocoder/mapzen.py
+++ b/geocoder/mapzen.py
@@ -19,7 +19,7 @@ class Mapzen(Base):
     method = 'geocode'
 
     def __init__(self, location, **kwargs):
-        self.url = 'https://search.mapzen.com/v1/search'
+        self.url = kwargs.get('url') or 'https://search.mapzen.com/v1/search'
         self.location = location
         self.params = {
             'text': location,

--- a/geocoder/mapzen_reverse.py
+++ b/geocoder/mapzen_reverse.py
@@ -20,7 +20,7 @@ class MapzenReverse(Mapzen):
     method = 'reverse'
 
     def __init__(self, location, **kwargs):
-        self.url = 'https://search.mapzen.com/v1/reverse'
+        self.url = kwargs.get('url') or 'https://search.mapzen.com/v1/reverse'
         self.location = location
         location = Location(location)
 


### PR DESCRIPTION
Since mapzen is open source and can run anywhere, I was thinking that we can customize the server url if the user provides one, so that the geocoder can work with any server running a mapzen api.