### PR TITLE
bugfix - prevent: TypeError: a bytes-like object is required, not 'str'

### DIFF
--- a/geocoder/mapquest.py
+++ b/geocoder/mapquest.py
@@ -38,7 +38,7 @@ class Mapquest(Base):
         self._initialize(**kwargs)
 
     def _catch_errors(self):
-        if self.content and 'The AppKey submitted with this request is invalid' in self.content:
+        if self.content and b'The AppKey submitted with this request is invalid' in self.content:
             raise ValueError('MapQuest API Key invalid')
 
     def _exceptions(self):


### PR DESCRIPTION
content is binary substr should be binary too (python2.7 & 3 compatible)