### PR TITLE
Docs: Fix link to ArcGIS developer documentation

### DIFF
--- a/docs/providers/ArcGIS.rst
+++ b/docs/providers/ArcGIS.rst
@@ -35,4 +35,4 @@ Parameters
 References
 ----------
 
-- `ArcGIS Geocode API <https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find.htm>`_
+- `ArcGIS Geocode API <https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm>`_


### PR DESCRIPTION
Just a small fix replacing a broken link with a working one.