### PR TITLE
Add the network plug to the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,7 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 apps:
   geocoder:
     command: bin/geocode
+    plugs: [network]
 
 parts:
   geocoder:


### PR DESCRIPTION
In order to make network requests on a strict snap, it is required to declare the plug.