### PR TITLE
Update requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ urllib3==1.21.1
 requests-mock==1.3.0
 sphinx==1.6.3
 mock==2.0.0
+future==0.16.0


### PR DESCRIPTION
Addresses https://github.com/DenisCarriere/geocoder/issues/298

Production package should really not be using "requirements-dev" when there's already a requirements file- this leads to confusion and bugs. 