### PR TITLE
Fixed error status_code from 200 to 0

### DIFF
--- a/geocoder/baidu.py
+++ b/geocoder/baidu.py
@@ -122,7 +122,7 @@ class BaiduQuery(MultipleResultsQuery):
 
     def _catch_errors(self, json_response):
         status_code = json_response.get('status')
-        if status_code != 200:
+        if status_code != 0:
             self.status_code = status_code
             self.error = json_response.get('message')
 


### PR DESCRIPTION
In the Baidu geocoding API [documentation]( http://lbsyun.baidu.com/index.php?title=lbscloud/api/appendix), status 200 is also an error code while 0 means status OK