### PR TITLE
add country_code as obtained from OSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Table of releases
 ## [Unreleased]
 
 * added opencage rate to show how many API queries remain for the day (issue #295)
+* added `country_code` result when geocoding with osm
 
 ## [1.32.1] - 2017-09-16
 

--- a/geocoder/__init__.py
+++ b/geocoder/__init__.py
@@ -28,7 +28,7 @@ Consistant JSON responses from various providers.
 __title__ = 'geocoder'
 __author__ = 'Denis Carriere'
 __author_email__ = 'carriere.denis@gmail.com'
-__version__ = '1.32.1'
+__version__ = '1.32.2'
 __license__ = 'MIT'
 __copyright__ = 'Copyright (c) 2013-2016 Denis Carriere'
 

--- a/geocoder/osm.py
+++ b/geocoder/osm.py
@@ -249,6 +249,11 @@ class OsmResult(OneResult):
         """admin_level=2"""
         return self._address.get('country')
 
+    @property
+    def country_code(self):
+        """admin_level=2"""
+        return self._address.get('country_code')
+
     # ======================== #
     # Quality Control & Others #
     # ======================== #


### PR DESCRIPTION
Some of the other geocoders in this module already provide the country_code, the OSM one hasn't so far. Nominatim does send a country_code, so let's use it!