### PR TITLE
Add future to setup.py - Fixes #318

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if not version:
 with open('README.md', 'r', 'utf-8') as f:
     readme = f.read()
 
-requires = ['requests', 'ratelim', 'click', 'six']
+requires = ['requests', 'ratelim', 'click', 'six', 'future']
 
 setup(
     name='geocoder',


### PR DESCRIPTION
Seems like `future` was missing in the `setup.py`, this should fix Issue https://github.com/DenisCarriere/geocoder/issues/318.

