### PR TITLE
Update gisgraphy.py

### DIFF
--- a/geocoder/gisgraphy.py
+++ b/geocoder/gisgraphy.py
@@ -62,6 +62,12 @@ class GisgraphyQuery(MultipleResultsQuery):
     _URL = 'https://services.gisgraphy.com/geocoding/'
     _RESULT_CLASS = GisgraphyResult
     _KEY_MANDATORY = False
+    
+    def _build_headers(self, provider_key, **kwargs):
+        return {
+            'Referer': "http://addxy.com/",
+            'User-agent': 'geocoder-converter'
+        }
 
     def _build_params(self, location, provider_key, **kwargs):
         return {

--- a/geocoder/gisgraphy.py
+++ b/geocoder/gisgraphy.py
@@ -65,7 +65,7 @@ class GisgraphyQuery(MultipleResultsQuery):
     
     def _build_headers(self, provider_key, **kwargs):
         return {
-            'Referer': "http://addxy.com/",
+            'Referer': "https://services.gisgraphy.com",
             'User-agent': 'geocoder-converter'
         }
 


### PR DESCRIPTION
Add user-agent to track geocoder converter requests and allow them (by default, free services is only allowed in a browser). 

will fix https://github.com/DenisCarriere/geocoder/pull/325#issuecomment-378441771 