### PR TITLE
Location parsing bugfix

### DIFF
--- a/geocoder/location.py
+++ b/geocoder/location.py
@@ -178,7 +178,7 @@ class BBox(object):
             self.north = float(lat) + self.DEGREES_TOLERANCE
             self.west = float(lng) - self.DEGREES_TOLERANCE
             self.east = float(lng) + self.DEGREES_TOLERANCE
-        elif all([west, south, east, north]):
+        elif not None in [west, south, east, north]:
             self.west, self.south, self.east, self.north = map(
                 float, [west, south, east, north])
         else:

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -9,9 +9,17 @@ class TestBBox(object):
         bbox = BBox.factory({'southwest': [43.0, -80.5], 'northeast': ["43.6", "-80.0"]})
         assert bbox.latlng == [43.3, -80.25]
 
+    def test_factory_bounds_dict_with_zero(self):
+        bbox = BBox.factory({'southwest': [0.0, -80.5], 'northeast': ["0.6", "-80.0"]})
+        assert bbox.latlng == [0.3, -80.25]
+
     def test_factory_bbox_dict(self):
         bbox = BBox.factory({'bbox': [-80.5, "43.0", "-80.0", 43.6]})
         assert bbox.latlng == [43.3, -80.25]
+
+    def test_factory_bbox_dict_with_zero(self):
+        bbox = BBox.factory({'bbox': [-80.5, "0.0", "-80.0", 0.6]})
+        assert bbox.latlng == [0.3, -80.25]
 
     def test_factory_latlng_dict(self):
         bbox = BBox.factory({'lat': 43.0, 'lng': "-80.0"})
@@ -22,9 +30,22 @@ class TestBBox(object):
         assert bbox.east == -79.5
         assert bbox.latlng == [43.0, -80.0]
 
+    def test_factory_latlng_dict_with_zero(self):
+        bbox = BBox.factory({'lat': 43.0, 'lng': "0.0"})
+        assert BBox.DEGREES_TOLERANCE == 0.5
+        assert bbox.south == 42.5
+        assert bbox.north == 43.5
+        assert bbox.west == -0.5
+        assert bbox.east == 0.5
+        assert bbox.latlng == [43.0, 0.0]
+
     def test_factory_coordinates_dict(self):
         bbox = BBox.factory({'south': "43.0", 'west': -80.5, 'north': "43.6", 'east': -80.0})
         assert bbox.latlng == [43.3, -80.25]
+
+    def test_factory_coordinates_dict_with_zero(self):
+        bbox = BBox.factory({'south': "43.0", 'west': -0.5, 'north': "43.6", 'east': 0.0})
+        assert bbox.latlng == [43.3, -0.25]
 
     def test_factory_error_dict(self):
         with pytest.raises(ValueError):
@@ -34,9 +55,17 @@ class TestBBox(object):
         bbox = BBox.factory([-80.5, "43.0", "-80.0", 43.6])
         assert bbox.latlng == [43.3, -80.25]
 
+    def test_factory_bounds_list_with_zero(self):
+        bbox = BBox.factory([-0.5, "43.0", "0.0", 43.6])
+        assert bbox.latlng == [43.3, -0.25]
+
     def test_factory_latlng_list(self):
         bbox = BBox.factory(["-80.0", "43.0"])
         assert bbox.latlng == [-80.0, 43.0]
+
+    def test_factory_latlng_list_with_zero(self):
+        bbox = BBox.factory(["0.0", "43.0"])
+        assert bbox.latlng == [0.0, 43.0]
 
     def test_factory_error_list(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Small bugfix, I had a case where one latitude, longitude in the bounding box was exactly 0.0, causing the creation of the bounding box to fail. Added tests.