### PR TITLE
Update LocationIQReverse

### DIFF
--- a/geocoder/locationiq_reverse.py
+++ b/geocoder/locationiq_reverse.py
@@ -2,6 +2,8 @@
 # coding: utf8
 
 from __future__ import absolute_import
+
+from geocoder.location import Location
 from geocoder.locationiq import LocationIQQuery
 
 
@@ -9,6 +11,21 @@ class LocationIQReverse(LocationIQQuery):
     provider = 'locationiq'
     method = 'reverse'
 
+    _URL = 'https://locationiq.org/v1/reverse.php'
+
+    def _build_params(self, location, provider_key, **kwargs):
+        location = Location(location)
+        return {
+            'format': 'json',
+            'key': provider_key,
+            'lat': location.latitude,
+            'lon': location.longitude,
+        }
+
+    def _adapt_results(self, json_response):
+        return [json_response]
+
+
 if __name__ == '__main__':
-    g = LocationIQReverse("45.3, -75.4")
+    g = LocationIQReverse("45.421106, -75.690308")
     g.debug()

--- a/tests/results/locationiq_reverse.json
+++ b/tests/results/locationiq_reverse.json
@@ -1,33 +1,28 @@
-[
-    {
-        "place_id": "85985426",
-        "licence": "API \u00a9 LocationIQ.org CC BY 4.0, Data \u00a9 OpenStreetMap contributors, ODbL 1.0",
-        "osm_type": "way",
-        "osm_id": "68588664",
-        "boundingbox": [
-            "45.4201768",
-            "45.4214404",
-            "-75.6908211",
-            "-75.6893108"
-        ],
-        "lat": "45.4208154",
-        "lon": "-75.6901176990294",
-        "display_name": "Ottawa City Hall, 110, Laurier Avenue West, Golden Triangle, Centretown, Somerset, Ottawa, Ontario, K2P 2K1, Canada",
-        "class": "building",
-        "type": "yes",
-        "importance": 0.31303438301933,
-        "address": {
-            "building": "Ottawa City Hall",
-            "house_number": "110",
-            "road": "Laurier Avenue West",
-            "neighbourhood": "Golden Triangle",
-            "suburb": "Centretown",
-            "city_district": "Somerset",
-            "city": "Ottawa",
-            "state": "Ontario",
-            "postcode": "K2P 2K1",
-            "country": "Canada",
-            "country_code": "ca"
-        }
-    }
-]
+{
+    "place_id": "90622554",
+    "licence": "\u00a9 LocationIQ.org CC BY 4.0, Data \u00a9 OpenStreetMap contributors, ODbL 1.0",
+    "osm_type": "way",
+    "osm_id": "68588664",
+    "lat": "45.4208154",
+    "lon": "-75.6901176990294",
+    "display_name": "Ottawa City Hall, 110, Laurier Avenue West, Golden Triangle, Centretown, Somerset, Ottawa, Ontario, K2P 2K1, Canada",
+    "address": {
+        "address29": "Ottawa City Hall",
+        "house_number": "110",
+        "road": "Laurier Avenue West",
+        "neighbourhood": "Golden Triangle",
+        "suburb": "Centretown",
+        "city_district": "Somerset",
+        "city": "Ottawa",
+        "state": "Ontario",
+        "postcode": "K2P 2K1",
+        "country": "Canada",
+        "country_code": "ca"
+    },
+    "boundingbox": [
+        "45.4201768",
+        "45.4214404",
+        "-75.6908211",
+        "-75.6893108"
+    ]
+}

--- a/tests/test_locationiq.py
+++ b/tests/test_locationiq.py
@@ -44,7 +44,7 @@ def test_locationiq_multi_result():
 
 
 def test_locationiq_reverse():
-    url = 'https://locationiq.org/v1/search.php?q=45.421106%2C+-75.690308&format=json&addressdetails=1&key=TEST_KEY'
+    url = 'https://locationiq.org/v1/reverse.php?format=json&key=TEST_KEY&lat=45.421106&lon=-75.690308'
     data_file = 'tests/results/locationiq_reverse.json'
     with requests_mock.Mocker() as mocker, open(data_file, 'r') as ip:
         mocker.get(url, text=ip.read())


### PR DESCRIPTION
Trying to use LocationIQ's reverse geocoding, I came across the same issue (partly) as mentioned in #353 . This PR updates `LocationIQReverse` to use their `'reverse.php'` endpoint and also updates the test accordingly. I didn't look at the OpenStreetMap yet so it seems like this PR might only be fixing 50% of #353 

Main changes:

  * Import `Location` to properly split given latitude/longitude
  * Modify `_URL` to use `reverse` endpoint instead
  * Modify `_build_params` for `reverse` endpoint
  * Modify `_adapt_results` to put single JSON response in a list
  * Modify coordinates in `LocationIQReverse` example (from unittest)

As I am new to this library, I'm not 100% sure if my modification of `_adapt_results` is the best way to achieve the correct response but it was raising errors without returning a single item list of `json_response`. If there is a better way, let me know and I will try to update this PR.

```python
def _adapt_results(self, json_response):
    return [json_response]
```

https://github.com/g-mc/geocoder/blob/7069fd23558b37f9f7e5ee701e333f6e5fce0c68/geocoder/locationiq_reverse.py#L25-L26

