### PR TITLE
Replaced deprecated freegeoip.net endpoint with freegeoip.live

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ $ geocode "Ottawa, ON" \
 | [Baidu][Baidu]                 | China     | API key                         |                  | yes     |           |       |
 | [Bing][Bing]                   | World     | API key                         | yes              | yes     |           | yes   |
 | [CanadaPost][CanadaPost]       | Canada    | API key                         | yes              |         |           |       |
-| [FreeGeoIP][FreeGeoIP] This API endpoint is deprecated and will stop working on July 1st, 2018.         | World     | Rate Limit, [Policy][FreeGeoip-Policy]                |                  |         |           |       |
+| [FreeGeoIP][FreeGeoIP]         | World     | Rate Limit, [Policy][FreeGeoip-Policy]                |                  |         |           |       |
 | [Gaode][Gaode]                 | China     | API key                         |                  | yes     |           |       |
 | [Geocoder.ca][Geocoder.ca] (Geolytica) | CA & US | Rate Limit                |                  |         |           |       |
 | [GeocodeFarm][GeocodeFarm]     | World     | [Policy][GeocodeFarm-Policy]    | yes              | yes     |           |       |

--- a/docs/providers/FreeGeoIP.rst
+++ b/docs/providers/FreeGeoIP.rst
@@ -1,6 +1,6 @@
-FreeGeoIP.net
+FreeGeoIP.live
 =============
-freegeoip.net provides a public HTTP API for software developers to
+freegeoip.live provides a public HTTP API for software developers to
 search the geolocation of IP addresses. It uses a database of IP addresses
 that are associated to cities along with other relevant information like
 time zone, latitude and longitude.
@@ -37,4 +37,4 @@ Parameters
 References
 ----------
 
-- `API Reference <http://freegeoip.net/>`_
+- `API Reference <https://freegeoip.live/>`_

--- a/geocoder/freegeoip.py
+++ b/geocoder/freegeoip.py
@@ -94,9 +94,9 @@ class FreeGeoIPResult(OneResult):
 
 class FreeGeoIPQuery(MultipleResultsQuery):
     """
-    FreeGeoIP.net
+    FreeGeoIP.live
     =============
-    freegeoip.net provides a public HTTP API for software developers to
+    freegeoip.live provides a public HTTP API for software developers to
     search the geolocation of IP addresses. It uses a database of IP addresses
     that are associated to cities along with other relevant information like
     time zone, latitude and longitude.
@@ -107,12 +107,12 @@ class FreeGeoIPQuery(MultipleResultsQuery):
 
     API Reference
     -------------
-    http://freegeoip.net/
+    https://freegeoip.live/
     """
     provider = 'freegeoip'
     method = 'geocode'
 
-    _URL = 'https://freegeoip.net/json/'
+    _URL = 'https://freegeoip.live/json/'
     _RESULT_CLASS = FreeGeoIPResult
     _KEY_MANDATORY = False
 


### PR DESCRIPTION
[Freegeoip.live](https://freegeoip.live) provides the same API as freegeoip.net provided before July 1, 2018. It has the same request rate policy (up to 10 000 queries per hour). So I suggest replacing freegeoip.net with freegeoip.live and removing the deprecation label from FreeGeoIP provider.