### PR TITLE
fix yandex geocoder when given full address

### DIFF
--- a/geocoder/yandex.py
+++ b/geocoder/yandex.py
@@ -85,7 +85,7 @@ class YandexResult(OneResult):
 
     @property
     def _locality(self):
-        return self._subAdministrativeArea.get('Locality', {})
+        return self._subAdministrativeArea.get('Locality') or {}
 
     @property
     def city(self):

--- a/tests/test_yandex.py
+++ b/tests/test_yandex.py
@@ -19,3 +19,8 @@ def test_yandex_reverse():
 def test_multi_results():
     g = geocoder.yandex(location, maxRows=3)
     assert len(g) == 3
+
+
+def test_yandex_full_russian_location():
+    g = geocoder.yandex('Химки, ул. Сенявинская д 11, кор 16')
+    assert g.ok


### PR DESCRIPTION
Check out what happens when invoking:
`
geocoder.yandex('Химки, ул. Сенявинская д 11, кор 16')
`

Got exception: 
`
AttributeError: 'str' object has no attribute 'get'
`
