### PR TITLE
added an option to pass `countrycode` to opencage

### DIFF
--- a/docs/providers/OpenCage.rst
+++ b/docs/providers/OpenCage.rst
@@ -51,6 +51,7 @@ Parameters
 - `location`: Your search location you want geocoded.
 - `key`: (optional) use your own API Key from OpenCage.
 - `maxRows`: (default=1) Max number of results to fetch
+- `countrycode`: (default=None) A string representing the country codes to restrict the search to (e.g. 'ca,us')
 - `method`: (default=geocode) Use the following:
 
     - geocode

--- a/geocoder/opencage.py
+++ b/geocoder/opencage.py
@@ -11,7 +11,6 @@ from geocoder.keys import opencage_key
 
 
 class OpenCageResult(OneResult):
-
     def __init__(self, json_content):
         # create safe shortcuts
         self._geometry = json_content.get('geometry', {})
@@ -403,6 +402,10 @@ class OpenCageQuery(MultipleResultsQuery):
         language = kwargs.get('language', None)
         if language:
             base_params['language'] = language
+
+        countrycode = kwargs.get('countrycode', None)
+        if countrycode:
+            base_params['countrycode'] = countrycode
 
         return base_params
 

--- a/tests/test_opencage.py
+++ b/tests/test_opencage.py
@@ -28,8 +28,13 @@ def test_opencage():
 
 
 def test_issue_292():
-    g = geocoder.opencage('AirportClinic M - MediCare Flughafen München Medizinisches Zentrum', countrycode='DE', language='de', no_annotations=1)
+    g = geocoder.opencage(
+        'AirportClinic M - MediCare Flughafen München Medizinisches Zentrum',
+        countrycode='DE',
+        language='de',
+        no_annotations=1)
     assert g.ok
+
 
 def test_opencage_no_language_param():
     """ Expected result :
@@ -38,12 +43,22 @@ def test_opencage_no_language_param():
     g = geocoder.opencage(location)
     assert 'language' not in g.url
 
+
 def test_opencage_language_param():
     """ Expected result :
         https://api.opencagedata.com/geocode/v1/json=Ottawa,Ontario&key=YOUR-API-KEY&language=de
     """
     g = geocoder.opencage(location, language='de')
     assert 'language=de' in g.url.split('&')
+
+
+def test_opencage_countrycode_param():
+    """ Expected result:
+        https://api.opencagedata.com/geocode/v1/json?q=Ottawa,Ontario&key=YOUR-API-KEY&countrycode=ca"
+    """
+    g = geocoder.opencage(location, countrycode='ca')
+    assert 'countrycode=ca' in g.url.split('&')
+
 
 def test_opencage_multi_result():
     g = geocoder.opencage(location, maxRows=5)
@@ -66,9 +81,11 @@ def test_opencage_address():
     assert (g.remaining_api_calls > 0 and g.remaining_api_calls != 999999)
     assert (g.limit_api_calls > 0 and g.remaining_api_calls != 999999)
 
+
 def test_opencage_paid():
     # Paid API keys can be set to unlimited and have rate limit information ommitted from the response
-    url = 'http://api.opencagedata.com/geocode/v1/json?query=The+Happy+Goat%2C+Ottawa&limit=1&key=' + os.environ.get('OPENCAGE_API_KEY')
+    url = 'http://api.opencagedata.com/geocode/v1/json?query=The+Happy+Goat%2C+Ottawa&limit=1&key=' + os.environ.get(
+        'OPENCAGE_API_KEY')
     data_file = 'tests/results/opencagedata_paid.json'
     with requests_mock.Mocker() as mocker, open(data_file, 'r') as input:
         mocker.get(url, text=input.read())
@@ -79,8 +96,6 @@ def test_opencage_paid():
         assert fields_count >= 15
         assert result.remaining_api_calls == 999999
         assert result.limit_api_calls == 999999
-
-
 
 
 def test_opencage_reverse():


### PR DESCRIPTION
This was missing, and it tends to make the results a lot better when it's available (e.g. 'AE' alone resolves to Armenia while 'AE' with 'AE' passed in the `countrycode` argument resolves to United Arab Emirates, which is correct).