### PR TITLE
docs: fix simple typo, usesage -> usage

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -96,7 +96,7 @@ IP Addresses
 Command Line Interface
 ----------------------
 
-Basic usesage with CLI
+Basic usage with CLI
 
 .. code-block:: bash
 


### PR DESCRIPTION
There is a small typo in docs/api.rst.

Should read `usage` rather than `usesage`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md