### PR TITLE
fix regex syntax error

### DIFF
--- a/geocoder/uscensus.py
+++ b/geocoder/uscensus.py
@@ -33,7 +33,7 @@ class USCensusResult(OneResult):
     @property
     def housenumber(self):
         if self.address:
-            match = re.search('^\d+', self.address, re.UNICODE)
+            match = re.search('^\\d+', self.address, re.UNICODE)
             if match:
                 return match.group(0)
 


### PR DESCRIPTION
regex string single backslash must be escaped with a second backslash