### PR TITLE
USCensus no longer served 2010 fields by default

### DIFF
--- a/geocoder/uscensus_reverse.py
+++ b/geocoder/uscensus_reverse.py
@@ -47,22 +47,22 @@ class USCensusReverseResult(OneResult):
 
     @property
     def block(self):
-        if self.raw['2010 Census Blocks']:
-            return self.raw['2010 Census Blocks'][0].get('NAME')
+        if self.raw['2020 Census Blocks']:
+            return self.raw['2020 Census Blocks'][0].get('NAME')
         elif self.raw['Census Blocks']:
             return self.raw['Census Blocks'][0].get('NAME')
 
     @property
     def blocknumber(self):
-        if self.raw['2010 Census Blocks']:
-            return self.raw['2010 Census Blocks'][0].get('BLOCK')
+        if self.raw['2020 Census Blocks']:
+            return self.raw['2020 Census Blocks'][0].get('BLOCK')
         elif self.raw['Census Blocks']:
             return self.raw['Census Blocks'][0].get('BLOCK')
 
     @property
     def geoid(self):
-        if self.raw['2010 Census Blocks']:
-            return self.raw['2010 Census Blocks'][0].get('GEOID')
+        if self.raw['2020 Census Blocks']:
+            return self.raw['2020 Census Blocks'][0].get('GEOID')
         elif self.raw['Census Blocks']:
             return self.raw['Census Blocks'][0].get('GEOID')
 


### PR DESCRIPTION
With the default settings, you now get the 2020 Census and the fields in the return are named accordingly. With the current code it fails with a KeyError. The change that I'm proposing is not perfect, as it trades compatibility with the 2020 census but won't work when users access the old 2010 Census. That could of course be done with more if..else statements or more clever parsing, but this is simple, works, and probably covers the vast majority of use cases.

```Python
import geocoder
geocoder.uscensus_reverse.USCensusReverse([42.3601, -71.0589])

---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[53], line 2
      1 import geocoder
----> 2 geocoder.uscensus_reverse.USCensusReverse([42.3601, -71.0589])

File ~/miniforge3/envs/passivemap/lib/python3.14/site-packages/geocoder/base.py:410, in MultipleResultsQuery.__init__(self, location, **kwargs)
    407 self._before_initialize(location, **kwargs)
    409 # query and parse results
--> 410 self._initialize()

File ~/miniforge3/envs/passivemap/lib/python3.14/site-packages/geocoder/base.py:465, in MultipleResultsQuery._initialize(self)
    463 # creates instances for results
    464 if not has_error:
--> 465     self._parse_results(json_response)

File ~/miniforge3/envs/passivemap/lib/python3.14/site-packages/geocoder/base.py:525, in MultipleResultsQuery._parse_results(self, json_response)
    519 """ Creates instances of self.one_result (validated cls._RESULT_CLASS)
    520     from JSON results retrieved by self._connect
    521 
    522     params: array of objects (dictionnaries)
    523 """
    524 for json_dict in self._adapt_results(json_response):
--> 525     self.add(self.one_result(json_dict))
    527 # set default result to use for delegation
    528 self.current_result = len(self) > 0 and self[0]

File ~/miniforge3/envs/passivemap/lib/python3.14/site-packages/geocoder/base.py:65, in OneResult.__init__(self, json_content)
     63 self.fieldnames = []
     64 self.json = {}
---> 65 self._parse_json_with_fieldnames()

File ~/miniforge3/envs/passivemap/lib/python3.14/site-packages/geocoder/base.py:122, in OneResult._parse_json_with_fieldnames(self)
    120 if not key.startswith('_') and key not in self._TO_EXCLUDE:
    121     self.fieldnames.append(key)
--> 122     value = getattr(self, key)
    123     if value:
    124         self.json[key] = value

File ~/miniforge3/envs/passivemap/lib/python3.14/site-packages/geocoder/uscensus_reverse.py:50, in USCensusReverseResult.block(self)
     48 @property
     49 def block(self):
---> 50     if self.raw['2010 Census Blocks']:
     51         return self.raw['2010 Census Blocks'][0].get('NAME')
     52     elif self.raw['Census Blocks']:

KeyError: '2010 Census Blocks'
```